### PR TITLE
fix: intercept Codex/Claude Code /v1/models requests in standard API middleware

### DIFF
--- a/src/server/proxy-server.ts
+++ b/src/server/proxy-server.ts
@@ -275,6 +275,43 @@ export class ProxyServer {
     // === 标准 API 路径前置中间件 ===
     // 处理 /v1/models 和 4 个可绑定的标准 API 路径
     this.app.use(async (req: Request, res: Response, next: NextFunction) => {
+      // 拦截 Codex/Claude Code 的模型列表请求，不转发到上游
+      // 上游（如 DeepSeek）的 /v1/models 响应格式与工具体系不兼容
+      const toolType = req.path.startsWith('/codex') ? 'codex'
+        : req.path.startsWith('/claude-code') ? 'claude-code'
+        : null;
+      if (toolType) {
+        const prefix = toolType === 'codex' ? '/codex' : '/claude-code';
+        const strippedPath = req.path.slice(prefix.length) || '/';
+        if (strippedPath === '/v1/models' || strippedPath === '/models') {
+          // 鉴权
+          if (this.config.apiKey) {
+            const authHeader = req.headers.authorization;
+            const providedKey = authHeader?.replace('Bearer ', '');
+            if (!providedKey || providedKey !== this.config.apiKey) {
+              res.status(401).json({ error: { message: 'Invalid API key' } });
+              return;
+            }
+          }
+          // 从激活路由的规则中收集模型名
+          const routeId = this.dbManager.getActiveRouteIdForTool(toolType);
+          if (routeId) {
+            const rules = this.dbManager.getRules(routeId);
+            const modelNames = [...new Set(
+              rules
+                .filter(r => r.targetModel)
+                .map(r => r.targetModel!.trim())
+                .filter(Boolean)
+            )];
+            const modelsStr = modelNames.length > 0 ? modelNames.join(',') : undefined;
+            res.json(buildModelsResponse(modelsStr));
+            return;
+          }
+          // 无激活路由时交由后续 fallback 处理
+          return next();
+        }
+      }
+
       const apiPath = matchApiPath(req.path);
       if (!apiPath) {
         return next();


### PR DESCRIPTION
## Problem

When Codex or Claude Code calls `/v1/models` to refresh available models at startup, the proxy forwards the request to the upstream provider (e.g. DeepSeek). Upstream APIs often don't support the model-list format expected by these tools, causing 405 or 503 errors:

- Codex log: `failed to refresh available models`
- Proxy log: `All services failed`

This is a persistent warning on every Codex startup when a route is active, though it doesn't block actual chat usage.

## Fix

Intercept `/codex/v1/models` and `/claude-code/v1/models` (and paths without `/v1` prefix) in the standard API path middleware — which already runs before the proxy routing logic and already handles `/v1/models` for direct API access.

When a route IS active:
- Collect model names from the route's rules (`targetModel` fields)
- Return them directly via the existing `buildModelsResponse()`

When no route is active:
- Fall through to the existing fallback mechanism (complements PR #72)

## Verification

Tested on running v5.1.2 instance:

```
$ curl http://127.0.0.1:4567/codex/v1/models
{"object":"list","data":[{"id":"deepseek-chat","object":"model","created":1747267200,"owned_by":"custom"}]}
```

- `/codex/v1/models` → returns model list from active route rules ✓
- `/codex/models` → same ✓
- `/codex/v1/responses` → proxies through normally ✓
- No route active → falls through to fallback ✓